### PR TITLE
cascade classifier(CvHaar..) and objdetect module

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -1,3 +1,6 @@
+use ffi::types::{CvSeq, CvRect};
+use ffi::core::*;
+
 #[deriving(Clone, PartialEq, Show)]
 pub struct Color {
   red: u8,
@@ -47,6 +50,43 @@ impl Rect {
 }
 
 pub type Scalar = [f64, ..4];
+
+pub struct Seq {
+  pub raw: *mut CvSeq,
+  pub curr: uint,
+}
+
+impl Iterator<Rect> for Seq {
+  fn next(&mut self) -> Option<Rect> {
+    unsafe {
+      if self.curr.lt(&self.len()) {
+        match cvGetSeqElem(&*self.raw, self.curr as int) {
+          c if c.is_not_null() => {
+            let rect = *(c as *mut CvRect);
+            self.curr += 1;
+            Some(Rect::new(rect.x as int, rect.y as int, rect.width as int, rect.height as int))
+          },
+          _ => None
+        }
+      } else {
+        None
+      }
+    }
+  }
+}
+
+impl Collection for Seq {
+  fn len(&self) -> uint {
+    unsafe { 
+      let total = (*self.raw).total;
+      if total.gt(&0) {
+        total as uint
+      } else {
+        0u
+      }
+    }
+  }
+}
 
 #[deriving(Clone, PartialEq, Show)]
 pub struct Size {

--- a/src/ffi/core.rs
+++ b/src/ffi/core.rs
@@ -1,10 +1,19 @@
-use ffi::types::{CvArr, CvMat, CvSize, IplImage};
+use ffi::types::{CvArr, CvMat, CvMemStorage, CvSeq, CvSize, IplImage};
+use libc::{c_char, c_int, c_schar, c_void};
 
 #[link(name = "opencv_core")]
 extern "C" {
   pub fn cvCloneImage(image: *const IplImage) -> *const IplImage;
   pub fn cvCloneMat(mat: *const CvMat) -> *const CvMat;
+  pub fn cvCreateMemStorage(block_size: c_int) -> *mut CvMemStorage;
+  pub fn cvGetSeqElem(seq: *const CvSeq, index: int) -> *mut c_schar;
   pub fn cvGetSize(mat: *const CvArr) -> CvSize;
+  pub fn cvLoad(
+    filename: *const c_char, 
+    memstorage: *mut CvMemStorage,
+    name: *const c_char,
+    real_name: *const c_char
+  ) -> *mut c_void;
   pub fn cvReleaseImage(image: *const *const IplImage);
   pub fn cvReleaseMat(mat: *const *const CvMat);
 }

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -1,5 +1,6 @@
 pub mod core;
 pub mod imgproc;
+pub mod objdetect;
 pub mod types;
 pub mod highgui;
 pub mod videoio;

--- a/src/ffi/objdetect.rs
+++ b/src/ffi/objdetect.rs
@@ -1,0 +1,9 @@
+use ffi::types::{CvArr, CvHaarClassifierCascade, CvMemStorage, CvSeq, CvSize};
+use libc::{c_int, c_double};
+
+#[link(name = "opencv_objdetect")]
+extern "C" {
+  pub fn cvHaarDetectObjects(image: *const CvArr, cascade: *mut CvHaarClassifierCascade, storage: *mut CvMemStorage,
+    scale_factor: c_double, min_neighbors: c_int, flags: c_int,
+    min_size: CvSize, max_size: CvSize) -> *mut CvSeq;
+}

--- a/src/ffi/types.rs
+++ b/src/ffi/types.rs
@@ -33,6 +33,9 @@ pub struct CvContourScanner;
 pub struct CvFont;
 
 #[repr(C)]
+pub struct CvHaarClassifierCascade;
+
+#[repr(C)]
 pub struct CvHistogram;
 
 #[repr(C)]
@@ -77,7 +80,15 @@ pub struct CvRect {
 pub type CvScalar = [c_double, ..4];
 
 #[repr(C)]
-pub struct CvSeq;
+pub struct CvSeq {
+  pub flags: c_int,
+  pub header_size: c_int,
+  pub h_prev: *mut CvSeq,
+  pub h_next: *mut CvSeq,
+  pub v_prev: *mut CvSeq,
+  pub v_next: *mut CvSeq,
+  pub total: c_int,
+}
 
 #[repr(C)]
 pub struct CvSeqBlock;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,5 +11,6 @@ extern crate libc;
 pub mod core;
 pub mod highgui;
 pub mod image;
+pub mod objdetect;
 pub mod video;
 mod ffi;

--- a/src/objdetect.rs
+++ b/src/objdetect.rs
@@ -1,0 +1,45 @@
+use ffi::types::{CvArr, CvHaarClassifierCascade, CvSize};
+use std::ptr;
+use core::{Size, Seq};
+use image::{Image};
+use ffi::objdetect::*;
+use ffi::core::*;
+
+pub struct CascadeClassifier {
+  raw: *mut CvHaarClassifierCascade
+}
+
+impl CascadeClassifier {
+  
+  pub fn load(path: &Path) -> Result<CascadeClassifier, String> {
+    path.with_c_str(|path_c_str| unsafe {
+      match cvLoad(path_c_str, ptr::null_mut(), ptr::null(), ptr::null()) {
+        c if c.is_not_null() => Ok(CascadeClassifier { raw: c as *mut CvHaarClassifierCascade }),
+        _ => Err(path_c_str.to_string()),
+      }
+    })
+  }
+
+  pub fn detect_multi_scale(&self, image: &Image, 
+    scale_factor: f64, min_neighbors: int, flags: int, 
+    min_size: Size, max_size: Size) -> Result<Seq, String> {
+
+    unsafe {
+      match cvHaarDetectObjects(
+        image.ptr() as *const CvArr, 
+        self.raw,
+        cvCreateMemStorage(0),
+        scale_factor,
+        min_neighbors as i32,
+        flags as i32,
+        CvSize { width: min_size.width as i32, height: min_size.height as i32 },
+        CvSize { width: max_size.width as i32, height: max_size.height as i32 }
+      ) {
+        r if r.is_not_null() => Ok(Seq { raw: r, curr: 0u }),
+        _ => Err("Something went wrong!".to_string())
+      }
+    }
+
+  }
+
+}


### PR DESCRIPTION
Added `CascadeClassifier` (`CvHaarClassifierCascade`) and the `objdetect` module (just the `cvHaarDetectObjects` method). I'm pretty certain the `cvHaarDetectObjects` method is from the older opencv version and is deprecated but I couldn't find any newer `C` methods for this..

Wasn't sure what to name the _safer_ version of `CvSeq` (or should I have just implemented an `Iterator` for `CvSeq`?) so I just named it `Seq` (`src/core::Seq`) but feel free to merge and change it to whatever fits.
