### PR TITLE
Ignore the return value of cvNamedWindow

### DIFF
--- a/src/highgui.rs
+++ b/src/highgui.rs
@@ -60,13 +60,11 @@ pub struct Window<'a> {
 }
 
 impl<'a> Window<'a> {
-  pub fn named(name: &str) -> Result<Window, String> {
+  pub fn named(name: &str) -> Window {
     name.with_c_str(|name_c_str| unsafe {
-      match cvNamedWindow(name_c_str, 1i32) {
-        0 => Ok(Window { name: name.to_string(), trackbars: Vec::new(), on_mouse: None }),
-        _ => Err(name.to_string()),
-      }
-    })
+        cvNamedWindow(name_c_str, 1i32);
+    });
+    Window { name: name.to_string(), trackbars: Vec::new(), on_mouse: None }
   }
 
   pub fn show(&self, image: &Image) {


### PR DESCRIPTION
I got a panic from `highgui::Window::named()` because the value returned from `cvNamedWindow()` was `1`. The [documentation for namedWindow](http://docs.opencv.org/modules/highgui/doc/user_interface.html#void%20namedWindow%28const%20string&%20winname,%20int%20flags%29) does not say anything about the return value and the current (C++) API of the library implements `cv::namedWindow()` like so:

```
// <opencv-src>/modules/highgui/src/window.cpp
void cv::namedWindow( const string& winname, int flags )
{
    cvNamedWindow( winname.c_str(), flags );
}
```

Wherein it just ignores the value returned by the lower level `cvNamedWindow()`. I think we should also do the same here. I've attached a patch, but I'm new to Rust and this project, so please let me know if I missed something. Thanks for the project!

[EDIT]
I'm on Linux 64 bit with GTK backend for OpenCV 2.4.3+, if that helps.
